### PR TITLE
Update 262-1 (Deutsche Telekom) B28 usage LTE->NR

### DIFF
--- a/src/data/countries/germany.json
+++ b/src/data/countries/germany.json
@@ -51,7 +51,7 @@
                     }
                 },
                  "technology": [
-                    "LTE"
+                    "NR"
                 ],
                 "source": [
                     {


### PR DESCRIPTION
They disabled B28 everywhere some time ago and now only use it for n28 NR.